### PR TITLE
Added golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,28 @@
+name: golangci-lint
+
+on:
+  workflow_call
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request.
+  # Use with `only-new-issues` option.
+  # pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          cache: false
+      - name: Install dependencies
+        run: go get .
+      - name: Lint with golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.53

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,5 +4,4 @@ rules:
   document-start:
     present: false
   truthy:
-    allowed-values: ['true', 'false', 'on']
-    check-keys: true
+    ignore: .github/workflows/*.yml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+pc: pca pcr
+
+pca: ## Updating hooks automatically
+	@pre-commit autoupdate
+
+pcr: ## Run against all the files
+	@pre-commit run -a


### PR DESCRIPTION
- Changed `truthy` block in `.yamllint.yml`
- Changed `on` block in `ci.yml` to run only on pushes to master branch or on pull requests
- Added `golangci-lint.yml` for linting with `golangci-lint`
- Added `Makefile` for `pre-commit` shortcuts